### PR TITLE
Fixed bug in RandomStretched function

### DIFF
--- a/jngen.h
+++ b/jngen.h
@@ -6869,7 +6869,7 @@ private:
             }
 
             edges.emplace_back(v, u);
-            usedEdges.insert({v, u});
+            usedEdges.emplace(v, u);
             attemptsToFail = MAX_ATTEMPTS;
         }
 

--- a/jngen.h
+++ b/jngen.h
@@ -6869,6 +6869,7 @@ private:
             }
 
             edges.emplace_back(v, u);
+            usedEdges.insert({v, u});
             attemptsToFail = MAX_ATTEMPTS;
         }
 


### PR DESCRIPTION
The function may produce undesired multiple edges even without allowMulti modifier.
Added `usedEdges` insert in `doRandomStretched` function.
